### PR TITLE
feed/chapter: localized chrome, valued progressbar and slide announcements (#1128)

### DIFF
--- a/src/feed/chapter.njk
+++ b/src/feed/chapter.njk
@@ -18,8 +18,9 @@ eleventyComputed:
      data-chapter-id="{{ pair.chapter.id }}"
      data-chapter-title="{{ pair.chapter.title }}"
      data-slide-count="{{ pair.chapter.slides.length }}">
+  <h1 class="sr-only">{{ pair.chapter.subtitle | tloc(pair.locale.code) }}</h1>
 
-  <div class="deck__progress" role="progressbar" aria-label="Chapter progress">
+  <div class="deck__progress" role="progressbar" aria-label="{{ 'feed_deck.progress_label' | t }}" aria-valuemin="1" aria-valuemax="{{ pair.chapter.slides.length }}" aria-valuenow="1" data-announce="{{ 'feed_deck.slide_of' | t }}">
     {% for slide in pair.chapter.slides %}
     <div class="deck__progress-seg{% if loop.first %} is-active{% endif %}" data-idx="{{ loop.index0 }}">
       <span class="deck__progress-fill"></span>
@@ -27,7 +28,7 @@ eleventyComputed:
     {% endfor %}
   </div>
 
-  <button class="deck__close" id="deckClose" aria-label="Exit chapter">
+  <button class="deck__close" id="deckClose" aria-label="{{ 'feed_deck.exit' | t }}">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
   </button>
 
@@ -36,8 +37,8 @@ eleventyComputed:
     <span class="deck__chapter-title">{{ pair.chapter.title }}</span>
   </div>
 
-  <button class="deck__tap deck__tap--prev" aria-label="Previous slide"></button>
-  <button class="deck__tap deck__tap--next" aria-label="Next slide"></button>
+  <button class="deck__tap deck__tap--prev" aria-label="{{ 'feed_deck.prev_slide' | t }}"></button>
+  <button class="deck__tap deck__tap--next" aria-label="{{ 'feed_deck.next_slide' | t }}"></button>
 
   {% for slide in pair.chapter.slides %}
   <article class="deck__slide{% if loop.first %} is-active{% endif %}"
@@ -88,8 +89,9 @@ eleventyComputed:
   {% endfor %}
 
   <div class="deck__hint" id="deckHint">
-    <span>tap →</span><span>swipe ↑ for depth</span><span>swipe ↓ to exit</span>
+    <span>{{ "feed_deck.hint_tap" | t }}</span><span>{{ "feed_deck.hint_depth" | t }}</span><span>{{ "feed_deck.hint_exit" | t }}</span>
   </div>
+  <div class="sr-only" id="deckLive" role="status" aria-live="polite"></div>
 
 {% if devMode %}{% include "dev-feedback.njk" %}{% endif %}
 </div>


### PR DESCRIPTION
Closes #1128.

The chapter deck template still shipped the pre-localization chrome that baf1fc9 fixed in deepcuts and source: hardcoded English aria-labels (Exit chapter / Previous slide / Next slide / Chapter progress), a progressbar with no value attributes, no slide-change live region, and no h1. Mirrored the same markup into chapter.njk: feed_deck.* localized labels, aria-valuemin/max/now with data-announce on the progressbar, the #deckLive status region, localized hint spans, and an sr-only h1. All feed_deck keys already existed in the five locale dicts; feed-deck.js needed no changes.

Verified on a clean production build with a 26-check Playwright run: French and English chapter01 pages show localized labels, valuenow tracks ArrowRight/ArrowLeft and tap navigation, the live region announces "Diapositive 2 sur 12" / "Slide 2 of 12", plus a French deepcuts smoke check — all pass with zero console errors.