### PR TITLE
markdown-pdf: block scheme-relative remote images in preview (#1130)

### DIFF
--- a/src/tools/markdown-pdf.njk
+++ b/src/tools/markdown-pdf.njk
@@ -182,7 +182,9 @@ function render() {
   previewEl.innerHTML = window.renderMarkdown ? window.renderMarkdown(inputEl.value || '') : '';
   previewEl.querySelectorAll('img').forEach((img) => {
     const src = img.getAttribute('src') || '';
-    if (/^https?:\/\//i.test(src) && new URL(src, location.href).origin !== location.origin) {
+    let resolved;
+    try { resolved = new URL(src, location.href); } catch (_) { return; }
+    if ((resolved.protocol === 'http:' || resolved.protocol === 'https:') && resolved.origin !== location.origin) {
       const note = document.createElement('span');
       note.className = 'mp__img-blocked';
       note.textContent = COPY.remoteImgBlocked.replace('{src}', src);


### PR DESCRIPTION
Closes #1130.

The preview's remote-image guard only fired when the src matched a literal http(s):// prefix, so protocol-relative URLs (//host/img.png) kept their <img> element: third-party hosts rendered a bare broken-image glyph (CSP blocked the load with no explanation) and allowlisted first-party CDN hosts loaded silently, contradicting the tool's stated blocked-and-announced behavior. Dropped the regex prefix gate and classified by URL parsing alone: any parseable http:/https: src that is cross-origin gets the localized blocked note; relative paths and data: images are untouched, and unparseable srcs are left for the CSP backstop.

Verified on a clean production build with a 13-check Playwright run: https://, //example.com, and //cdn.mentria.ai images are all replaced by the localized note, relative and data: images still render, the French page shows the translated notice, and no unexpected console errors — all pass.