### PR TITLE
sudoku and ludo: save and resume the game in progress (#1201)

### DIFF
--- a/src/tools/ludo.njk
+++ b/src/tools/ludo.njk
@@ -218,6 +218,41 @@ eleventyComputed:
   function curPlayer(){ return State.active[State.turnIdx]; }
   function isHuman(p){ return State.mode === 'hotseat' ? true : p === 0; }
 
+  function save(){
+    if (State.over) return;
+    const data = {
+      mode: State.mode, numPlayers: State.numPlayers, active: State.active,
+      tokens: State.tokens, turnIdx: State.turnIdx, sixStreak: State.sixStreak,
+      finishers: State.finishers
+    };
+    try {
+      if (window.MentriaStore) window.MentriaStore.set('games', 'ludo', data);
+      else localStorage.setItem('mentria_ludo_v1', JSON.stringify(data));
+    } catch(e){}
+  }
+  function clearSave(){
+    try {
+      if (window.MentriaStore) window.MentriaStore.remove('games', 'ludo');
+      else localStorage.removeItem('mentria_ludo_v1');
+    } catch(e){}
+  }
+  function load(){
+    try {
+      let d = window.MentriaStore ? window.MentriaStore.get('games', 'ludo') : null;
+      if (!d){ const raw = localStorage.getItem('mentria_ludo_v1'); if (raw) d = JSON.parse(raw); }
+      if (!d || !Array.isArray(d.tokens) || d.tokens.length !== 4 || !Array.isArray(d.active) || !d.active.length) return false;
+      if (!d.tokens.every(t => Array.isArray(t) && t.length === 4)) return false;
+      State.mode = d.mode === 'hotseat' ? 'hotseat' : 'ai';
+      State.numPlayers = [2,3,4].includes(d.numPlayers) ? d.numPlayers : 4;
+      State.active = d.active;
+      State.tokens = d.tokens;
+      State.turnIdx = (d.turnIdx >= 0 && d.turnIdx < d.active.length) ? d.turnIdx : 0;
+      State.sixStreak = d.sixStreak || 0;
+      State.finishers = Array.isArray(d.finishers) ? d.finishers : [];
+      return true;
+    } catch(e){ return false; }
+  }
+
   let gen = 0;
   let diceInterval = null;
   function gtimeout(fn, ms){ const g = gen; return setTimeout(() => { if (g === gen) fn(); }, ms); }
@@ -235,6 +270,14 @@ eleventyComputed:
     State.dice = 0; State.rolled = false; State.rolling = false; State.sixStreak = 0;
     State.movable = []; State.over = false; State.winner = -1; State.finishers = [];
     State.animating = false;
+    document.getElementById('overlay').classList.remove('show');
+    renderPlayers(); draw(); updateDie(0); setStatus(); updateRollBtn();
+    save();
+    maybeAITurn();
+  }
+  function resume(){
+    modeSeg.set(State.mode);
+    countSeg.set(State.numPlayers);
     document.getElementById('overlay').classList.remove('show');
     renderPlayers(); draw(); updateDie(0); setStatus(); updateRollBtn();
     maybeAITurn();
@@ -482,6 +525,7 @@ eleventyComputed:
     if (extra && State.sixStreak < 3){
       State.rolled = false; State.movable = [];
       setStatus(); updateDie(0); updateRollBtn();
+      save();
       if (!isHuman(p)) gtimeout(()=>aiRoll(p), 600);
     } else {
       endTurn();
@@ -494,6 +538,7 @@ eleventyComputed:
     do { State.turnIdx = (State.turnIdx + 1) % State.active.length; }
     while (State.tokens[curPlayer()].every(x => x === 56) && State.finishers.length < State.active.length);
     updateDie(0); draw(); renderPlayers(); setStatus(); updateRollBtn();
+    save();
     maybeAITurn();
   }
   function maybeAITurn(){
@@ -547,6 +592,7 @@ eleventyComputed:
 
   function finishGame(p){
     State.over = true;
+    clearSave();
     const who = isHuman(p) ? (State.mode==='hotseat'?COPY.wonHuman:COPY.wonYou) : COPY.wonBot;
     const m = document.getElementById('modal');
     m.innerHTML = `<p class="eyebrow">${COPY.winEyebrow}</p>
@@ -573,10 +619,10 @@ eleventyComputed:
     document.getElementById('overlay').classList.add('show');
     document.getElementById('m-close').onclick = () => document.getElementById('overlay').classList.remove('show');
   };
-  MentriaUI.segmented(document.getElementById('mode-seg'), (value) => {
+  const modeSeg = MentriaUI.segmented(document.getElementById('mode-seg'), (value) => {
     State.mode = value; newGame();
   });
-  MentriaUI.segmented(document.getElementById('count-seg'), (value) => {
+  const countSeg = MentriaUI.segmented(document.getElementById('count-seg'), (value) => {
     State.numPlayers = +value; newGame();
   });
   document.addEventListener('keydown', e => {
@@ -671,6 +717,6 @@ eleventyComputed:
     announce(COPY.winTitle.replace('{name}', PNAMES[p]) + '. ' + who);
   };
 
-  newGame();
+  if (load()) resume(); else newGame();
 })();
 </script>

--- a/src/tools/sudoku.njk
+++ b/src/tools/sudoku.njk
@@ -214,6 +214,43 @@ eleventyComputed:
     else try { localStorage.setItem('mentria_sudoku_best_' + diff, String(s)); } catch (_) {}
   }
 
+  function save(){
+    if (State.over || !State.solution.length) return;
+    const data = {
+      diff: State.diff, solution: State.solution, puzzle: State.puzzle,
+      grid: State.grid, given: State.given, notes: State.notes.map(s => Array.from(s)),
+      mistakes: State.mistakes, hints: State.hints, elapsed: State.elapsed, notesMode: State.notesMode
+    };
+    try {
+      if (window.MentriaStore) window.MentriaStore.set('games', 'sudoku', data);
+      else localStorage.setItem('mentria_sudoku_v1', JSON.stringify(data));
+    } catch(e){}
+  }
+  function clearSave(){
+    try {
+      if (window.MentriaStore) window.MentriaStore.remove('games', 'sudoku');
+      else localStorage.removeItem('mentria_sudoku_v1');
+    } catch(e){}
+  }
+  function load(){
+    try {
+      let d = window.MentriaStore ? window.MentriaStore.get('games', 'sudoku') : null;
+      if (!d){ const raw = localStorage.getItem('mentria_sudoku_v1'); if (raw) d = JSON.parse(raw); }
+      if (!d || !Array.isArray(d.grid) || d.grid.length !== 81 || !Array.isArray(d.solution) || d.solution.length !== 81) return false;
+      State.diff = DIFF[d.diff] ? d.diff : State.diff;
+      State.solution = d.solution;
+      State.puzzle = Array.isArray(d.puzzle) && d.puzzle.length === 81 ? d.puzzle : d.grid.slice();
+      State.grid = d.grid;
+      State.given = Array.isArray(d.given) && d.given.length === 81 ? d.given : State.puzzle.map(v => v !== 0);
+      State.notes = Array.from({length:81}, (_, i) => new Set(Array.isArray(d.notes && d.notes[i]) ? d.notes[i] : []));
+      State.mistakes = d.mistakes || 0;
+      State.hints = typeof d.hints === 'number' ? d.hints : 3;
+      State.elapsed = d.elapsed || 0;
+      State.notesMode = !!d.notesMode;
+      return true;
+    } catch(e){ return false; }
+  }
+
   function shuffle(a){ for(let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } return a; }
   function solveCount(g, limit){
     const idx = g.indexOf(0);
@@ -303,6 +340,19 @@ eleventyComputed:
     State.timer = setInterval(tick, 1000);
     overlay.classList.remove('show');
     document.getElementById('hint-count').textContent = State.hints;
+    buildBoard(); render(); updateHUD(); save();
+  }
+  function resume(){
+    if (State.timer) clearInterval(State.timer);
+    State.started = performance.now() - State.elapsed*1000;
+    State.timer = setInterval(tick, 1000);
+    overlay.classList.remove('show');
+    document.getElementById('hint-count').textContent = State.hints;
+    if (State.notesMode){
+      document.getElementById('btn-notes').classList.add('active');
+      document.getElementById('notes-state').textContent = COPY.notesOn;
+    }
+    diffSeg.set(State.diff);
     buildBoard(); render(); updateHUD();
   }
   function tick(){
@@ -390,9 +440,9 @@ eleventyComputed:
     if (State.given[i]) return;
     if (State.notesMode && n!==0){
       if (State.notes[i].has(n)) State.notes[i].delete(n); else State.notes[i].add(n);
-      render(); return;
+      render(); save(); return;
     }
-    if (n===0){ State.grid[i]=0; State.notes[i].clear(); render(); announce(COPY.aErased); return; }
+    if (n===0){ State.grid[i]=0; State.notes[i].clear(); render(); announce(COPY.aErased); save(); return; }
     State.notes[i].clear();
     State.grid[i] = n;
     if (n!==0){
@@ -409,7 +459,7 @@ eleventyComputed:
     } else {
       announce(COPY.aPlaced.replace('{n}', n));
     }
-    render(); checkWin();
+    render(); checkWin(); save();
   }
 
   function checkWin(){
@@ -420,6 +470,7 @@ eleventyComputed:
   function gameOver(won){
     State.over = true; State.won = won;
     if (State.timer) clearInterval(State.timer);
+    clearSave();
     if (won) writeBest(State.diff, State.elapsed);
     const m = document.getElementById('modal');
     const best = readBest(State.diff);
@@ -463,7 +514,7 @@ eleventyComputed:
     document.getElementById('hint-count').textContent = State.hints;
     render();
     announce(COPY.aPlaced.replace('{n}', State.solution[target]));
-    checkWin();
+    checkWin(); save();
     showToast(COPY.hintToast.replace('{n}', State.hints));
     focusCell(target);
   }
@@ -531,18 +582,19 @@ eleventyComputed:
     State.notesMode = !State.notesMode;
     document.getElementById('btn-notes').classList.toggle('active', State.notesMode);
     document.getElementById('notes-state').textContent = State.notesMode ? COPY.notesOn : COPY.notesOff;
+    save();
   }
 
   document.getElementById('btn-notes').onclick = toggleNotes;
   document.getElementById('btn-erase').onclick = () => placeNumber(0);
   document.getElementById('btn-hint').onclick = useHint;
   document.getElementById('btn-new').onclick = newGame;
-  MentriaUI.segmented(document.getElementById('diff-seg'), (value) => {
+  const diffSeg = MentriaUI.segmented(document.getElementById('diff-seg'), (value) => {
     State.diff = value;
     newGame();
   });
 
   buildKeypad();
-  newGame();
+  if (load()) resume(); else newGame();
 })();
 </script>


### PR DESCRIPTION
Closes #1201.

Sudoku only persisted best times and Ludo persisted nothing, so a reload, navigation, or mobile tab eviction discarded the game in progress. Both now follow the save/resume pattern Chess already ships: state is written to the games MentriaStore namespace (localStorage fallback) on every state change and silently restored on load.

Sudoku saves the solution, puzzle, current grid, notes, givens, difficulty, mistakes, remaining hints, notes mode, and elapsed time; the timer re-anchors to the saved elapsed on restore, and winning or losing clears the save. Ludo saves at each quiescent point (new game, completed move, turn change): piece positions, whose turn, active players, mode, player count, and the six-streak; finishing the game clears the save, and an unspent die roll simply re-rolls after restore.

Verified with a Playwright run against the production build: mid-game reloads restore the full board for both games (Ludo asserted via the a11y board summary plus a canvas pixel hash), game over clears the save, segmented controls reflect restored settings, a Spanish-locale round-trip works, and Chess still boots with no console errors.